### PR TITLE
Remove unused path aliases

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,10 +21,7 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./app/*"],
-      "@/components/*": ["./components/*"],
-      "@/lib/*": ["./lib/*"],
-      "@/types/*": ["./types/*"],
-      "@/utils/*": ["./utils/*"]
+      "@/components/*": ["./components/*"]
     },
     "forceConsistentCasingInFileNames": true,
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
## Summary
- prune unused path aliases from tsconfig

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: React types missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c9b95761c832995521714f531215c