### PR TITLE
Demo hero layout with overlay navigation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import './globals.css'
-import Header from '../components/layout/Header'
 import Footer from '../components/layout/Footer'
 
 // Initialize Inter font with variable weights
@@ -32,7 +31,6 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${inter.variable} scroll-smooth`}>
       <body className="font-sans antialiased bg-bg-primary text-scientific-900 min-h-screen flex flex-col">
-        <Header />
         <main className="flex-grow">
           {children}
         </main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,204 +1,84 @@
-import React from 'react';
-import Card from '@/components/ui/Card';
-import PageWrapper from '@/components/layout/PageWrapper';
-import { CertificationBadge } from '@/components/content/CertificationBadge';
+import React from 'react'
+import Link from 'next/link'
+import Card from '@/components/ui/Card'
 
 export default function HomePage() {
   return (
-    <PageWrapper>
-      {/* Hero Section */}
-      <section className="relative py-24 lg:py-32">
-        <div className="max-w-4xl">
-          {/* Molecular pattern accent */}
-          <div className="absolute -top-8 -left-8 w-32 h-32 opacity-5">
-            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-              <circle cx="20" cy="20" r="8" fill="#03045e" />
-              <circle cx="80" cy="20" r="8" fill="#03045e" />
-              <circle cx="50" cy="50" r="10" fill="#0077b6" />
-              <circle cx="20" cy="80" r="8" fill="#03045e" />
-              <circle cx="80" cy="80" r="8" fill="#03045e" />
-              <line x1="20" y1="20" x2="50" y2="50" stroke="#03045e" strokeWidth="1" opacity="0.3" />
-              <line x1="80" y1="20" x2="50" y2="50" stroke="#03045e" strokeWidth="1" opacity="0.3" />
-              <line x1="20" y1="80" x2="50" y2="50" stroke="#03045e" strokeWidth="1" opacity="0.3" />
-              <line x1="80" y1="80" x2="50" y2="50" stroke="#03045e" strokeWidth="1" opacity="0.3" />
-            </svg>
+    <div className="min-h-screen flex flex-col">
+      {/* Hero Section with overlay navigation */}
+      <section className="relative h-screen w-full">
+        <img
+          src="https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=1950&q=80"
+          alt="Hero"
+          className="absolute inset-0 w-full h-full object-cover"
+        />
+        <div className="absolute inset-0 bg-black/50" />
+
+        {/* Navigation Bar */}
+        <div className="absolute top-0 left-0 w-full z-20">
+          <div className="container-scientific flex items-center justify-between py-4">
+            <div className="bg-white text-scientific-950 font-semibold px-4 py-2 rounded shadow-molecular">
+              EGA
+            </div>
+            <nav className="flex gap-6">
+              <Link href="/" className="text-white font-medium hover:text-accent transition-colors">Home</Link>
+              <Link href="/projects" className="text-white font-medium hover:text-accent transition-colors">Projects</Link>
+              <Link href="/thought-cast" className="text-white font-medium hover:text-accent transition-colors">Thought-cast</Link>
+              <Link href="/oncogenomics" className="text-white font-medium hover:text-accent transition-colors">Oncogenomics</Link>
+            </nav>
           </div>
-          
-          <h1 className="text-display font-semibold text-scientific-950 mb-6 animate-fade-in">
-            Erick Geovany Artola
-          </h1>
-          <p className="text-h2 text-scientific-700 mb-8 animate-fade-in" style={{ animationDelay: '0.1s' }}>
-            AI/ML Engineer • Genomics Researcher • Technical Account Manager
-          </p>
-          <p className="text-h3 text-scientific-600 leading-relaxed max-w-3xl animate-fade-in" style={{ animationDelay: '0.2s' }}>
-            Bridging artificial intelligence and genomics to advance our understanding of complex biological systems. 
-            Currently applying machine learning techniques to oncogenomics research while serving as an AWS Technical Account Manager.
-          </p>
+        </div>
+
+        {/* Tagline */}
+        <div className="relative z-10 flex items-center justify-center h-full px-4 text-center">
+          <div>
+            <h1 className="text-display font-semibold text-white drop-shadow-md">
+              Accelerating Genomic Insights with AI
+            </h1>
+            <p className="text-h2 text-white mt-4 drop-shadow-md">
+              Exploring machine learning at the molecular level
+            </p>
+          </div>
         </div>
       </section>
 
-      {/* About Section */}
-      <section className="py-16 lg:py-24">
-        <h2 className="text-h1 font-semibold text-scientific-950 mb-12">About</h2>
-        
-        <div className="grid gap-8 lg:grid-cols-2">
-          <Card className="space-y-6">
-            <div className="space-y-4">
-              <h3 className="text-h2 font-medium text-scientific-950">Background</h3>
-              <p className="text-body text-scientific-700 leading-relaxed">
-                Originally from Nicaragua and now based in Costa Rica, I bring a unique perspective to the intersection 
-                of technology and life sciences. My journey from Central America to the forefront of AI and genomics 
-                research reflects my commitment to leveraging cutting-edge technology for global impact.
-              </p>
-              <p className="text-body text-scientific-700 leading-relaxed">
-                As an AWS Technical Account Manager, I help organizations architect and optimize their cloud infrastructure 
-                for AI/ML workloads, particularly in the healthcare and biotech sectors. This role allows me to stay at 
-                the cutting edge of cloud computing while directly supporting genomics research initiatives.
-              </p>
+      {/* Content Grid */}
+      <section className="py-16 lg:py-24 bg-bg-secondary">
+        <div className="container-scientific grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+          <Card className="p-0 overflow-hidden" hover>
+            <img
+              src="https://images.unsplash.com/photo-1542831371-29b0f74f9713?auto=format&fit=crop&w=800&q=80"
+              alt="Research"
+              className="w-full h-48 object-cover"
+            />
+            <div className="p-6">
+              <h3 className="text-h3 font-medium text-scientific-950">Research Blog</h3>
             </div>
           </Card>
-          
-          <Card className="space-y-6">
-            <div className="space-y-4">
-              <h3 className="text-h2 font-medium text-scientific-950">Research Interests</h3>
-              <p className="text-body text-scientific-700 leading-relaxed">
-                My primary focus lies in applying artificial intelligence to genomics, particularly in understanding 
-                oncogenic pathways and developing computational methods for cancer research. I'm passionate about 
-                creating AI models that can identify patterns in genomic data that might lead to breakthrough treatments.
-              </p>
-              <p className="text-body text-scientific-700 leading-relaxed">
-                Beyond technical pursuits, I maintain a deep interest in robotics and postmodern literature, believing 
-                that interdisciplinary thinking is crucial for innovation. This diverse intellectual foundation informs 
-                my approach to complex problems in computational biology.
-              </p>
+
+          <Card className="p-0 overflow-hidden md:col-span-2" hover>
+            <img
+              src="https://images.unsplash.com/photo-1504904126297-1ce789964136?auto=format&fit=crop&w=1200&q=80"
+              alt="Featured"
+              className="w-full h-48 object-cover"
+            />
+            <div className="p-6">
+              <h3 className="text-h3 font-medium text-scientific-950">Featured Project</h3>
+            </div>
+          </Card>
+
+          <Card className="p-0 overflow-hidden" hover>
+            <img
+              src="https://images.unsplash.com/photo-1506784983877-45594efa4cbe?auto=format&fit=crop&w=800&q=80"
+              alt="Publications"
+              className="w-full h-48 object-cover"
+            />
+            <div className="p-6">
+              <h3 className="text-h3 font-medium text-scientific-950">Publications</h3>
             </div>
           </Card>
         </div>
       </section>
-
-      {/* Experience Timeline */}
-      <section className="py-16 lg:py-24">
-        <h2 className="text-h1 font-semibold text-scientific-950 mb-12">Professional Journey</h2>
-        
-        <div className="space-y-8">
-          {/* Current Role */}
-          <div className="relative pl-8 pb-8 border-l-2 border-scientific-200 last:border-l-0">
-            <div className="absolute -left-2 top-0 w-4 h-4 bg-accent rounded-full border-4 border-white shadow-molecular" />
-            <div className="space-y-3">
-              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
-                <h3 className="text-h2 font-medium text-scientific-950">Technical Account Manager</h3>
-                <span className="text-small text-scientific-600">2023 - Present</span>
-              </div>
-              <p className="text-body text-scientific-700 font-medium">Amazon Web Services (AWS)</p>
-              <p className="text-body text-scientific-700 leading-relaxed">
-                Leading technical strategy for enterprise healthcare and biotech clients, specializing in architecting 
-                cloud solutions for genomics pipelines, ML model training, and high-performance computing workloads. 
-                Key achievements include optimizing genomic analysis workflows resulting in 60% cost reduction and 
-                3x performance improvement.
-              </p>
-            </div>
-          </div>
-          
-          {/* Research Focus */}
-          <div className="relative pl-8 pb-8 border-l-2 border-scientific-200">
-            <div className="absolute -left-2 top-0 w-4 h-4 bg-secondary rounded-full border-4 border-white shadow-molecular" />
-            <div className="space-y-3">
-              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
-                <h3 className="text-h2 font-medium text-scientific-950">Independent Research</h3>
-                <span className="text-small text-scientific-600">2022 - Present</span>
-              </div>
-              <p className="text-body text-scientific-700 font-medium">AI Applications in Oncogenomics</p>
-              <p className="text-body text-scientific-700 leading-relaxed">
-                Developing machine learning models for identifying cancer biomarkers and predicting treatment responses. 
-                Current projects include deep learning approaches for analyzing tumor heterogeneity and transformer-based 
-                models for genomic sequence analysis.
-              </p>
-            </div>
-          </div>
-          
-          {/* Education/Early Career */}
-          <div className="relative pl-8">
-            <div className="absolute -left-2 top-0 w-4 h-4 bg-scientific-500 rounded-full border-4 border-white shadow-molecular" />
-            <div className="space-y-3">
-              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
-                <h3 className="text-h2 font-medium text-scientific-950">Technical Foundation</h3>
-                <span className="text-small text-scientific-600">2020 - 2022</span>
-              </div>
-              <p className="text-body text-scientific-700 leading-relaxed">
-                Built comprehensive technical expertise through intensive self-directed learning and professional 
-                certifications. Focused on cloud architecture, machine learning, and bioinformatics to prepare 
-                for the intersection of AI and genomics.
-              </p>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Certifications Section */}
-      <section className="py-16 lg:py-24">
-        <h2 className="text-h1 font-semibold text-scientific-950 mb-12">Technical Certifications</h2>
-        
-        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-          <CertificationBadge
-            title="AWS Certified Solutions Architect"
-            issuer="Amazon Web Services"
-            date="2023"
-            credentialId="AWS-SAA-C03"
-          />
-          <CertificationBadge
-            title="AWS Certified Machine Learning"
-            issuer="Amazon Web Services"
-            date="2023"
-            credentialId="AWS-MLS-C01"
-          />
-          <CertificationBadge
-            title="Google IT Support Professional"
-            issuer="Google"
-            date="2022"
-            credentialId="COURSERA-CERT"
-          />
-          <CertificationBadge
-            title="IBM AI Engineering Professional"
-            issuer="IBM"
-            date="2022"
-            credentialId="IBM-AI-ENG"
-          />
-          <CertificationBadge
-            title="AWS Certified Cloud Practitioner"
-            issuer="Amazon Web Services"
-            date="2022"
-            credentialId="AWS-CLF-C01"
-          />
-          <CertificationBadge
-            title="Deep Learning Specialization"
-            issuer="DeepLearning.AI"
-            date="2022"
-            credentialId="COURSERA-DL"
-          />
-        </div>
-      </section>
-
-      {/* Call to Action */}
-      <section className="py-16 lg:py-24 border-t border-scientific-100">
-        <div className="text-center space-y-8 max-w-3xl mx-auto">
-          <h2 className="text-h1 font-semibold text-scientific-950">
-            Let's Advance Science Together
-          </h2>
-          <p className="text-h3 text-scientific-700 leading-relaxed">
-            I'm always interested in collaborating on projects at the intersection of AI and genomics. 
-            Whether you're working on computational biology challenges, need cloud architecture expertise 
-            for life sciences applications, or want to discuss the future of AI in healthcare, I'd love to connect.
-          </p>
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <button className="btn-primary">
-              View Research Projects
-            </button>
-            <button className="btn-secondary">
-              Get in Touch
-            </button>
-          </div>
-        </div>
-      </section>
-    </PageWrapper>
-  );
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary
- remove default header from layout
- implement hero section with full-width image background and overlay navigation bar
- add tagline centered over the hero image
- include grid of content cards after the hero image

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685d5af032a883298c0a457246d1bfcc